### PR TITLE
Limiting verbosity

### DIFF
--- a/R/build_jabba.R
+++ b/R/build_jabba.R
@@ -90,7 +90,8 @@ build_jabba <- function(
   KOBE.type = c("ICCAT","IOTC")[2], # ICCAT uses 3 colors; IOTC 4 (incl. orange)
   Biplot= FALSE, # Produces a "post-modern" biplot with buffer and target zones (Quinn & Collie 2005)
   harvest.label = c("Hmsy","Fmsy")[2], # choose label preference H/Hmsy versus Fmsy
-  catch.metric = "(t)" # Define catch input metric e.g. (tons) "000 t" etc
+  catch.metric = "(t)", # Define catch input metric e.g. (tons) "000 t" etc
+  verbose=TRUE
 ){
 
 
@@ -103,7 +104,8 @@ build_jabba <- function(
   #-------------------------
   # Prepare input data
   #-------------------------
-  cat("\n","><> Prepare JABBA input data <><","\n","\n")
+  if(verbose)
+  message("\n","><> Prepare JABBA input data <><","\n","\n")
 
 
   if(is.null(catch)) stop("\n","\n","><> Catch Time series not provided <><","\n","\n")
@@ -116,7 +118,8 @@ build_jabba <- function(
   if(is.null(se)) SE.I = FALSE
   if(is.null(cpue)){
     CatchOnly = TRUE
-    cat(paste0("\n","><> Running Catch-Only mode: CatchOnly = TRUE <><","\n","\n"))
+    if(verbose)
+    message(paste0("\n","><> Running Catch-Only mode: CatchOnly = TRUE <><","\n","\n"))
     cpue= catch[,1:2]
     colnames(cpue) = c("Year","Dummy Index")
     cpue[,2] = NA
@@ -140,7 +143,8 @@ build_jabba <- function(
   conv.catch = as.numeric(rbind(matrix(rep(NA,(styr.C-1)*n.catches),styr.C-1,n.catches),as.matrix(catch[,-1])))
 
   if(length(which(conv.catch<0.0001)>0)) {
-    cat(paste0("\n","><> Warnning: Replacing 0 Catch by small constant 0.0001 <><","\n","\n"))
+    if(verbose)
+      message(paste0("\n","><> Warnning: Replacing 0 Catch by small constant 0.0001 <><","\n","\n"))
     conv.catch[conv.catch< 0.001]=0
   }
   if(length(which(is.na(conv.catch)))>0) stop("\n","\n","><> Missing Catch values currently not permitted (NAs should be 0) <><","\n","\n")
@@ -148,7 +152,8 @@ build_jabba <- function(
   # Build Catch input
   Catch=matrix(conv.catch,nrow=n.years,ncol=n.catches)
   if(ncol(Catch)>1){
-    cat(paste0("\n","><> Aggrigating multiple catch colums (assumed by fleet) to a single total catch column <><","\n","\n"))
+    if(verbose)
+      message(paste0("\n","><> Aggrigating multiple catch colums (assumed by fleet) to a single total catch column <><","\n","\n"))
     Catch = apply(Catch,1,sum)
   }
   TC = as.numeric(Catch) # Total Catch
@@ -156,9 +161,11 @@ build_jabba <- function(
   # Catch CV option.
   if(add.catch.CV==TRUE){
     if(length(catch.cv)>1) {CV.C =catch.cv[,2]} else {CV.C = rep(catch.cv,length(TC))}
-    cat("\n","><> Assume Catch with error CV = ",mean(CV.C)," <><","\n","\n")
+    if(verbose)
+    message("\n","><> Assume Catch with error CV = ",mean(CV.C)," <><","\n","\n")
   } else {
-    cat("\n","><> Assume Catch to be known without error <><","\n","\n")
+    if(verbose)
+    message("\n","><> Assume Catch to be known without error <><","\n","\n")
   }
 
 
@@ -175,7 +182,8 @@ build_jabba <- function(
   # Build Standard Error matrix
   if(is.null(se)){SE.I=FALSE} else {SE.I=TRUE}
   if(SE.I==FALSE){
-    cat("\n","><> SE.I=FALSE: Creatinng SE dummy matrix <><","\n","\n")
+    if(verbose)
+    message("\n","><> SE.I=FALSE: Creatinng SE dummy matrix <><","\n","\n")
     se = cpue
     conv.se = as.numeric(rbind(matrix(rep(NA,(styr.I-1)*n.indices),styr.I-1,n.indices),as.matrix(cpue[,-1])))
     se2 = matrix(ifelse(fixed.obsE>0,fixed.obsE^2,10^-10),n.years,n.indices)#/2
@@ -306,18 +314,21 @@ build_jabba <- function(
   Priors$log.sd = sqrt(log(Priors[,2]^2+1))
 
   
-  cat("\n","><> Model type:",model.type," <><","\n")
-  if(model<4){cat("\n","><> Shape m =",m ,"\n")} else {cat("\n","><> Shape m is estmated with a mean",m,"and a CV",shape.CV,"\n")}
-  cat("\n","><> K prior mean =",K.pr[1],"and CV =", CV.K,"(log.sd = ",K.pr[2],")","\n")
-  cat("\n","><> r prior mean =",r.pr[1],"and CV =", CV.r,"(log.sd = ",r.pr[2],")","\n")
-  cat("\n","><> Psi (B1/K) prior mean =",psi.prior[1],"and CV =",psi.prior[2],"with",psi.dist,"destribution","\n")
+  if(verbose) {
+  message("\n","><> Model type:",model.type," <><","\n")
+  if(model<4){message("\n","><> Shape m =",m ,"\n")} else {message("\n","><> Shape m is estmated with a mean",m,"and a CV",shape.CV,"\n")}
+  message("\n","><> K prior mean =",K.pr[1],"and CV =", CV.K,"(log.sd = ",K.pr[2],")","\n")
+  message("\n","><> r prior mean =",r.pr[1],"and CV =", CV.r,"(log.sd = ",r.pr[2],")","\n")
+  message("\n","><> Psi (B1/K) prior mean =",psi.prior[1],"and CV =",psi.prior[2],"with",psi.dist,"destribution","\n")
+  }
   
   
   
   #----------------------------------------------------------
   # Set up JABBA
   #----------------------------------------------------------
-  cat("\n","\n","\n","><> ALWAYS ENSURE to adjust default settings to your specific stock <><","\n","\n")
+  if(verbose)
+    message("\n","\n","\n","><> ALWAYS ENSURE to adjust default settings to your specific stock <><","\n","\n")
   # Plot MSY
   # remove scientific numbers
   options(scipen=999)

--- a/R/fit_jabba.R
+++ b/R/fit_jabba.R
@@ -52,7 +52,9 @@ fit_jabba = function(jbinput,
                      save.jabba = FALSE,
                      save.csvs = FALSE,
                      output.dir = getwd(),
-                     quickmcmc = FALSE
+                     quickmcmc = FALSE,
+                     verbose=TRUE,
+                     progress.bar = "text"
                      
 ){
   #write jabba model
@@ -108,7 +110,7 @@ fit_jabba = function(jbinput,
 
   ptm <- proc.time()
 
-  mod <- R2jags::jags(jbd, inits,params,paste0(tempdir(),"/JABBA.jags"), n.chains = nc, n.thin = nt, n.iter = ni, n.burnin = nb)  # adapt is burn-in
+  mod <- R2jags::jags(jbd, inits,params,paste0(tempdir(),"/JABBA.jags"), n.chains = nc, n.thin = nt, n.iter = ni, n.burnin = nb, quiet=!verbose, progress.bar = progress.bar)  # adapt is burn-in
 
   proc.time() - ptm
   save.time = proc.time() - ptm
@@ -127,7 +129,8 @@ fit_jabba = function(jbinput,
 
   # if run with library(rjags)
   posteriors = mod$BUGSoutput$sims.list
-  cat(paste0("\n","><> Produce results output of ",settings$model.type," model for ",settings$assessment," ",settings$scenario," <><","\n"))
+  if(verbose)
+  message(paste0("\n","><> Produce results output of ",settings$model.type," model for ",settings$assessment," ",settings$scenario," <><","\n"))
 
   #-----------------------------------------------------------
   # <><<><<><<><<><<><<>< Outputs ><>><>><>><>><>><>><>><>><>
@@ -213,7 +216,8 @@ fit_jabba = function(jbinput,
   #-------------------------------------------------------
   
   if(jbinput$settings$projection==TRUE){
-    cat("\n","><> compiling Future Projections under fixed quota <><","\n")
+  if(verbose)
+    message("\n","><> compiling Future Projections under fixed quota <><","\n")
     pyrs = jbinput$jagsdata$pyrs
     TACs = jbinput$jagsdata$TAC[pyrs,] 
     nTAC = length(TACs) 
@@ -334,7 +338,8 @@ fit_jabba = function(jbinput,
   out=data.frame(posteriors[params[sel.par]])
   outman = man.dat[,1:4]
   colnames(outman) = c("Fmsy","Bmsy","MSY","BmsyK")
-  cat(paste0("\n","\n",paste0("><> Scenario ", jbinput$settings$scenario,"_",jbinput$settings$model.type," completed in ",as.integer(save.time[3]/60)," min and ",round((save.time[3]/60-as.integer(save.time[3]/60))*100)," sec <><","\n")))
+  if(verbose)
+  message(paste0("\n","\n",paste0("><> Scenario ", jbinput$settings$scenario,"_",jbinput$settings$model.type," completed in ",as.integer(save.time[3]/60)," min and ",round((save.time[3]/60-as.integer(save.time[3]/60))*100)," sec <><","\n")))
 
 
 

--- a/R/fit_jabba.R
+++ b/R/fit_jabba.R
@@ -57,8 +57,12 @@ fit_jabba = function(jbinput,
                      progress.bar = "text"
                      
 ){
+
+  tmpath <- tempfile()
+  dir.create(tmpath)
+
   #write jabba model
-  jabba2jags(jbinput)
+  jabba2jags(jbinput, tmpath)
   
   # mcmc saved
   nsaved = (ni-nb)/nt*nc
@@ -110,7 +114,7 @@ fit_jabba = function(jbinput,
 
   ptm <- proc.time()
 
-  mod <- R2jags::jags(jbd, inits,params,paste0(tempdir(),"/JABBA.jags"), n.chains = nc, n.thin = nt, n.iter = ni, n.burnin = nb, quiet=!verbose, progress.bar = progress.bar)  # adapt is burn-in
+  mod <- R2jags::jags(jbd, inits,params,file.path(tmpath,"JABBA.jags"), n.chains = nc, n.thin = nt, n.iter = ni, n.burnin = nb, quiet=!verbose, progress.bar = progress.bar)  # adapt is burn-in
 
   proc.time() - ptm
   save.time = proc.time() - ptm

--- a/R/jabba2jags.R
+++ b/R/jabba2jags.R
@@ -4,11 +4,10 @@
 #' @param jbinput JABBA input object from build_jabba()
 #' @export
 
-jabba2jags = function(jbinput){
-
+jabba2jags = function(jbinput, dir){
 
   # JAGS MODEL Standard
-  sink(paste0(tempdir(),"/JABBA.jags"))
+  sink(file.path(dir,"JABBA.jags"))
   cat("
 
     model {
@@ -71,7 +70,7 @@ jabba2jags = function(jbinput){
 
   if(jbinput$settings$sigma.est==TRUE){
     cat("
-      # Obsevation variance
+      # Observation variance
       for(i in 1:nvar)
       {
       # Observation error
@@ -91,7 +90,7 @@ jabba2jags = function(jbinput){
       }}
       ",append=TRUE)
   }else{ cat("
-      # Obsevation variance
+      # Observation variance
            for(i in 1:nvar)
            {
            # Observation error


### PR DESCRIPTION
Calling jags inside multicore mse call to mp(), so interested in less output on screen. So
- Added a verbose=TRUE argument that will stop all messages if set to FALSE
- Added progress.bar=TRUE argument to be passed to jags

I also suggest changing calls to cat() to message() as it plays better with logging pkgs, and can be suppressed if needed.