### PR TITLE
Bug and documentation fixes for jbplot_ensemble

### DIFF
--- a/R/jbplot_ensemble.R
+++ b/R/jbplot_ensemble.R
@@ -59,6 +59,7 @@
 #' it will be the directory where the model was run.
 #' @param filenameprefix Additional text to append to PNG or PDF file names.
 #' It will be separated from default name by an underscore.
+#' @param single.plots if TRUE will plot subplots individually
 #' @param par list of graphics parameter values passed to par() function
 #' @param verbose Report progress to R GUI?
 #' @param shadecol uncertainty shading of hcxval horizon
@@ -69,6 +70,7 @@
 #' @author Mostly adopted from ss3diags::SSplotEnsemble
 #' @export
 #' @examples
+#' \dontrun{
 #' data(iccat)
 #' bet = iccat$bet 
 #' # Fit Fox and Schaefer
@@ -85,6 +87,9 @@
 #' jbplot_ensemble(prj)
 #' # Zoom in
 #' jbplot_ensemble(prj,xlim=c(2000,2027))
+#' # Plot only biomass
+#' jbplot_ensemble(list(fit1, fit2), subplots = 3, single.plots = TRUE)
+#' }
 jbplot_ensemble<- function(kb,
                         subplots=1:6,
                         joint=FALSE,
@@ -222,7 +227,7 @@ jbplot_ensemble<- function(kb,
   
   if(!single.plots){
   Par = list(mfrow=c(3,2),mai=c(0.45,0.49,0.1,.15),omi = c(0.15,0.15,0.1,0) + 0.1,mgp=c(2,0.5,0), tck = -0.02,cex=0.8)
-  if(as.png==TRUE){png(file = paste0(output.dir,"/",prefix,"_",jbs$assessment,".png"), width = 7, height = 8,
+  if(as.png==TRUE){png(file = paste0(plotdir,"/",filenameprefix,"_jabba_comparison.png"), width = 7, height = 8,
                        res = 200, units = "in")}
   par(Par)
   }

--- a/man/jbplot_ensemble.Rd
+++ b/man/jbplot_ensemble.Rd
@@ -160,6 +160,8 @@ It will be separated from default name by an underscore.}
 
 \item{add}{surpresses par() to create multiplot figs}
 
+\item{single.plots}{if TRUE will plot subplots individually}
+
 \item{run}{name for single models or joint ensembles}
 
 \item{legendcex=1}{Allows to adjust legend cex}
@@ -168,6 +170,7 @@ It will be separated from default name by an underscore.}
 Plots plots JABBA ensemble models + projections - joint or by run
 }
 \examples{
+\dontrun{
 data(iccat)
 bet = iccat$bet 
 # Fit Fox and Schaefer
@@ -184,6 +187,9 @@ prj = fw_jabba(list(fit1),quant="Catch",type="abs",imp.values = seq(60,100,1)*10
 jbplot_ensemble(prj)
 # Zoom in
 jbplot_ensemble(prj,xlim=c(2000,2027))
+# Plot only biomass
+jbplot_ensemble(list(fit1, fit2), subplots = 3, single.plots = TRUE)
+}
 }
 \author{
 Mostly adopted from ss3diags::SSplotEnsemble


### PR DESCRIPTION
Hi @jabbamodel 
When working with JABBA I realized that the `single.plots` argument of `jbplot_ensemble()` was not documented but it is a very useful argument if one needs to display the subplots singularly so I added in the parameter to the documentation. Also, when trying to save the figure as a png I was getting errors because `output.dir`, `prefix`, and `jabba$assessment` were not defined variables (line 230). I changed these variable names to match the input arguments (`plotdir`, `filenameprefix`, and "jabba_comparison.png" respectively). 
If you would like me to do anything additional for this PR, please let me know. 
Thank you!