### PR TITLE
Move return statement for 'kb' variable out of 'if(plot)'

### DIFF
--- a/R/jbplot_ensemble.R
+++ b/R/jbplot_ensemble.R
@@ -383,9 +383,8 @@ jbplot_ensemble<- function(kb,
     quant=quants[s]
     plot_quants(quant)   
     }
-    if(kbout) return(kb)
   } # endplot
-
+  if(kbout) return(kb)
 } 
 #}}} end of jbplot_ensemble()
 #-----------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixing return statement for `kbout` that was inside `if` condition for unrelated variable `plot`.